### PR TITLE
lib: make GovernorError pub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,7 +1215,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tower_governor"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "axum",
  "forwarded-header-value",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub mod key_extractor;
 use crate::governor::{Governor, GovernorConfig};
 use ::governor::clock::{Clock, DefaultClock, QuantaInstant};
 use ::governor::middleware::{NoOpMiddleware, RateLimitingMiddleware, StateInformationMiddleware};
-use errors::GovernorError;
+pub use errors::GovernorError;
 use futures_core::ready;
 use http::response::Response;
 
@@ -44,12 +44,10 @@ where
 }
 
 /// https://stegosaurusdormant.com/understanding-derive-clone/
-impl<K: KeyExtractor, M: RateLimitingMiddleware<QuantaInstant>> Clone
-    for GovernorLayer<'_, K, M>
-{
+impl<K: KeyExtractor, M: RateLimitingMiddleware<QuantaInstant>> Clone for GovernorLayer<'_, K, M> {
     fn clone(&self) -> Self {
         Self {
-            config: self.config.clone()
+            config: self.config.clone(),
         }
     }
 }


### PR DESCRIPTION
Making GovernorError pub. I need to match inner error types and have a custom error handling. 
In my case I use https://www.rfc-editor.org/rfc/rfc7807 https://crates.io/crates/http-api-problem to return errors in this format.