### PR TITLE
rework error handling inside govenor layer.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tracing = { version = "0.1.37", features = ["attributes"] }
 hyper = "0.14.23"
 reqwest = { version = "0.11.22", features = ["json"] }
 serde_json = "1.0.89"
+tower = "0.4"
 tower-http = { version = "0.5", features = ["trace"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 

--- a/README.md
+++ b/README.md
@@ -79,18 +79,10 @@ async fn main() {
     let app = Router::new()
         // `GET /` goes to `root`
         .route("/", get(hello))
-        .layer(
-            ServiceBuilder::new()
-                // this middleware goes above `GovernorLayer` because it will receive
-                // errors returned by `GovernorLayer`
-                .layer(HandleErrorLayer::new(|e: BoxError| async move {
-                    display_error(e)
-                }))
-                .layer(GovernorLayer {
+        .layer(GovernorLayer {
                     // We can leak this because it is created once and then
                     config: Box::leak(governor_conf),
-                }),
-        );
+        });
 
     // run our app with hyper
     // `axum::Server` is a re-export of `hyper::Server`

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::net::TcpListener;
 use tower::ServiceBuilder;
-use tower_governor::{errors::display_error, governor::GovernorConfigBuilder, GovernorLayer};
+use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
 
 async fn hello() -> &'static str {
     "Hello world"
@@ -139,7 +139,9 @@ async fn main() {
 
  # Error Handling
 
- This crate surfaces a GovernorError with suggested headers, and includes a [`display_error`]: crate::errors::display_error() function that will turn those errors into a Response. Feel free to provide your own error handler that takes in a BoxError and returns a [`Response`](https://docs.rs/http/latest/http/response/struct.Response.html). Tower Layers require that all Errors be handled, or it will fail to compile. 
+ This crate surfaces a GovernorError with suggested headers, and includes [`GovernorConfigBuilder::error_handler`] method that will turn those errors into a Response. Feel free to provide your own error handler that takes in [`GovernorError`] and returns a [`Response`](https://docs.rs/http/latest/http/response/struct.Response.html). 
+
+[`GovernorConfigBuilder::error_handler`]: crate::governor::GovernorConfigBuilder::error_handler
 
  # Common pitfalls
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ async fn main() {
         // `GET /` goes to `root`
         .route("/", get(hello))
         .layer(GovernorLayer {
-                    // We can leak this because it is created once and then
-                    config: Box::leak(governor_conf),
+            // We can leak this because it is created once and then
+            config: Box::leak(governor_conf),
         });
 
     // run our app with hyper

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,6 @@
 use http::{HeaderMap, Response, StatusCode};
 use std::mem;
 use thiserror::Error;
-use tower::BoxError;
 
 /// The error type returned by tower-governor.
 #[derive(Debug, Error, Clone)]
@@ -20,22 +19,6 @@ pub enum GovernorError {
         msg: Option<String>,
         headers: Option<HeaderMap>,
     },
-}
-/// Used in the Error Handler Middleware(for Axum) to convert GovernorError into a Response
-/// This one returns a String Body with the error message, and applies a HTTP Status Code, Headers,
-/// and msg body from the Error, if included.
-/// Feel free to use your own, as long as it returns a Response
-pub fn display_error(mut e: BoxError) -> Response<String> {
-    if e.is::<GovernorError>() {
-        // It shouldn't be possible for this to panic, since we already know it's a GovernorError
-        e.downcast_mut::<GovernorError>().unwrap().as_response()
-    } else {
-        let response = Response::new("Internal Server Error".to_string());
-        let (mut parts, body) = response.into_parts();
-        parts.status = StatusCode::INTERNAL_SERVER_ERROR;
-
-        Response::from_parts(parts, body)
-    }
 }
 
 impl GovernorError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
 use http::{HeaderMap, Response, StatusCode};
+use std::mem;
 use thiserror::Error;
 use tower::BoxError;
 
@@ -24,11 +25,25 @@ pub enum GovernorError {
 /// This one returns a String Body with the error message, and applies a HTTP Status Code, Headers,
 /// and msg body from the Error, if included.
 /// Feel free to use your own, as long as it returns a Response
-pub fn display_error(e: BoxError) -> Response<String> {
+pub fn display_error(mut e: BoxError) -> Response<String> {
     if e.is::<GovernorError>() {
         // It shouldn't be possible for this to panic, since we already know it's a GovernorError
-        let error = e.downcast_ref::<GovernorError>().unwrap().to_owned();
-        match error {
+        e.downcast_mut::<GovernorError>().unwrap().as_response()
+    } else {
+        let response = Response::new("Internal Server Error".to_string());
+        let (mut parts, body) = response.into_parts();
+        parts.status = StatusCode::INTERNAL_SERVER_ERROR;
+
+        Response::from_parts(parts, body)
+    }
+}
+
+impl GovernorError {
+    pub(crate) fn as_response<ResB>(&mut self) -> Response<ResB>
+    where
+        ResB: From<String>,
+    {
+        match mem::replace(self, Self::UnableToExtractKey) {
             GovernorError::TooManyRequests { wait_time, headers } => {
                 let response = Response::new(format!("Too Many Requests! Wait for {}s", wait_time));
                 let (mut parts, body) = response.into_parts();
@@ -36,14 +51,14 @@ pub fn display_error(e: BoxError) -> Response<String> {
                 if let Some(headers) = headers {
                     parts.headers = headers;
                 }
-                Response::from_parts(parts, body)
+                Response::from_parts(parts, ResB::from(body))
             }
             GovernorError::UnableToExtractKey => {
                 let response = Response::new("Unable To Extract Key!".to_string());
                 let (mut parts, body) = response.into_parts();
                 parts.status = StatusCode::INTERNAL_SERVER_ERROR;
 
-                Response::from_parts(parts, body)
+                Response::from_parts(parts, ResB::from(body))
             }
             GovernorError::Other { msg, code, headers } => {
                 let response = Response::new("Other Error!".to_string());
@@ -56,14 +71,8 @@ pub fn display_error(e: BoxError) -> Response<String> {
                     body = msg;
                 }
 
-                Response::from_parts(parts, body)
+                Response::from_parts(parts, ResB::from(body))
             }
         }
-    } else {
-        let response = Response::new("Internal Server Error".to_string());
-        let (mut parts, body) = response.into_parts();
-        parts.status = StatusCode::INTERNAL_SERVER_ERROR;
-
-        Response::from_parts(parts, body)
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,9 +1,8 @@
-use axum::{error_handling::HandleErrorLayer, routing::get, Router};
-use tower::{BoxError, ServiceBuilder};
+use axum::{routing::get, Router};
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-use crate::{errors::display_error, governor::GovernorConfigBuilder, GovernorLayer};
+use crate::{governor::GovernorConfigBuilder, GovernorLayer};
 
 #[tokio::main]
 async fn _main() {
@@ -44,17 +43,9 @@ fn app() -> Router {
             "/",
             get(|| async { "Hello, World!" }).post(|| async { "Hello, Post World!" }),
         )
-        .layer(
-            ServiceBuilder::new()
-                // this middleware goes above `GovernorLayer` because it will receive
-                // errors returned by `GovernorLayer`
-                .layer(HandleErrorLayer::new(|e: BoxError| async move {
-                    display_error(e)
-                }))
-                .layer(GovernorLayer {
-                    config: Box::leak(config),
-                }),
-        )
+        .layer(GovernorLayer {
+            config: Box::leak(config),
+        })
         .layer(TraceLayer::new_for_http())
 }
 
@@ -200,17 +191,9 @@ mod governor_tests {
                     "/",
                     get(|| async { "Hello, World!" }).post(|| async { "Hello, Post World!" }),
                 )
-                .layer(
-                    ServiceBuilder::new()
-                        // this middleware goes above `GovernorLayer` because it will receive
-                        // errors returned by `GovernorLayer`
-                        .layer(HandleErrorLayer::new(|e: BoxError| async move {
-                            display_error(e)
-                        }))
-                        .layer(GovernorLayer {
-                            config: Box::leak(config),
-                        }),
-                )
+                .layer(GovernorLayer {
+                    config: Box::leak(config),
+                })
                 .layer(TraceLayer::new_for_http());
             tx.send(()).unwrap();
             axum::serve(
@@ -272,17 +255,9 @@ mod governor_tests {
                     "/",
                     get(|| async { "Hello, World!" }).post(|| async { "Hello, Post World!" }),
                 )
-                .layer(
-                    ServiceBuilder::new()
-                        // this middleware goes above `GovernorLayer` because it will receive
-                        // errors returned by `GovernorLayer`
-                        .layer(HandleErrorLayer::new(|e: BoxError| async move {
-                            display_error(e)
-                        }))
-                        .layer(GovernorLayer {
-                            config: Box::leak(config),
-                        }),
-                )
+                .layer(GovernorLayer {
+                    config: Box::leak(config),
+                })
                 .layer(TraceLayer::new_for_http());
             tx.send(()).unwrap();
             axum::serve(
@@ -310,7 +285,7 @@ mod governor_tests {
             res.headers()
                 .get(HeaderName::from_static("x-ratelimit-remaining"))
                 .unwrap(),
-            "0" //TODO: Should this be 1?!?
+            "1" //TODO: Should this be 1?!?
         );
         assert!(res
             .headers()
@@ -458,17 +433,9 @@ mod governor_tests {
                     "/",
                     get(|| async { "Hello, World!" }).post(|| async { "Hello, Post World!" }),
                 )
-                .layer(
-                    ServiceBuilder::new()
-                        // this middleware goes above `GovernorLayer` because it will receive
-                        // errors returned by `GovernorLayer`
-                        .layer(HandleErrorLayer::new(|e: BoxError| async move {
-                            display_error(e)
-                        }))
-                        .layer(GovernorLayer {
-                            config: Box::leak(config),
-                        }),
-                )
+                .layer(GovernorLayer {
+                    config: Box::leak(config),
+                })
                 .layer(TraceLayer::new_for_http());
             tx.send(()).unwrap();
             axum::serve(
@@ -496,7 +463,7 @@ mod governor_tests {
             res.headers()
                 .get(HeaderName::from_static("x-ratelimit-remaining"))
                 .unwrap(),
-            "0" //TODO: Should this be 1?!?
+            "1" //TODO: Should this be 1?!?
         );
         assert!(res
             .headers()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -285,7 +285,7 @@ mod governor_tests {
             res.headers()
                 .get(HeaderName::from_static("x-ratelimit-remaining"))
                 .unwrap(),
-            "1" //TODO: Should this be 1?!?
+            "1"
         );
         assert!(res
             .headers()
@@ -463,7 +463,7 @@ mod governor_tests {
             res.headers()
                 .get(HeaderName::from_static("x-ratelimit-remaining"))
                 .unwrap(),
-            "1" //TODO: Should this be 1?!?
+            "1"
         );
         assert!(res
             .headers()


### PR DESCRIPTION
Change how error is handled inside governor. Instead of returning `BoxError` through `Service::Error` governor middleware would produce `http::Response<String>` type and return it trough `Service::Response`. In order to work with generic body type of `http::Response<B>` the `B` type must impl `From<String>` trait. 

With this change `HandleErrorLayer` becomes optional when crate is used with `axum`.

Close #16 