### PR TITLE
make axum optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 hyper = "0.14.23"
 reqwest = { version = "0.11.22", features = ["json"] }
 serde_json = "1.0.89"
-tower = { version = "0.4", features = ["full"] }
+tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.5", features = ["trace"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,27 +13,28 @@ categories = ["web-programming::http-server"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.7"
 forwarded-header-value = "0.1.1"
-futures = "0.3.25"
-futures-core = "0.3.25"
 governor = "0.6.0"
 http = "1.0.0"
 pin-project = "1.0.12"
 thiserror = "1.0.37"
-tokio = { version = "1.23.0", features = ["full"] }
 tower = "0.4.13"
-tower-layer = "0.3.2"
 tracing = { version = "0.1.37", features = ["attributes"] }
 
+axum = { version = "0.7", optional = true }
+
 [dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 hyper = "0.14.23"
 reqwest = { version = "0.11.22", features = ["json"] }
 serde_json = "1.0.89"
-tower = "0.4"
+tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.5", features = ["trace"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 
 [features]
+default = ["axum"]
+# Enables support for axum web framework
+axum = ["dep:axum"]
 # Enables tracing output for this middleware
 tracing = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ use crate::governor::{Governor, GovernorConfig};
 use ::governor::clock::{Clock, DefaultClock, QuantaInstant};
 use ::governor::middleware::{NoOpMiddleware, RateLimitingMiddleware, StateInformationMiddleware};
 pub use errors::GovernorError;
-use futures_core::ready;
 use http::response::Response;
 
 use http::header::{HeaderName, HeaderValue};
@@ -19,7 +18,7 @@ use http::HeaderMap;
 use key_extractor::KeyExtractor;
 use pin_project::pin_project;
 use std::task::{Context, Poll};
-use std::{future::Future, pin::Pin};
+use std::{future::Future, pin::Pin, task::ready};
 use tower::{Layer, Service};
 
 /// The Layer type that implements tower::Layer and is passed into `.layer()`


### PR DESCRIPTION
- Rework feature flags and make `axum` a default feature that can be opt-out.
- When `axum` feature is disabled ip key extractors would expect `std::net::SocketAddr` type from `http::Request`'s `http::Extensions` type map. Add library document for feature flags.
- Reduce dependency tree: Remove `futures` and `futures-core` as `axum` 0.7 itself has a MSRV of 1.66 which is beyond some extended `std::future` and `std::task` types and macros. Move `tokio` to dev-dependencies session. Remove `tower-layer` as it's not used anywhere.

Close #18 