### PR TITLE
fix: use body axum type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,15 +1223,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,9 +1364,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2 0.5.3",
  "tokio-macros",
  "windows-sys",
@@ -1464,12 +1453,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tower_governor"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "axum",
  "forwarded-header-value",
- "futures",
- "futures-core",
  "governor",
  "http 1.0.0",
  "hyper 0.14.27",
@@ -1480,7 +1467,6 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
- "tower-layer",
  "tracing",
  "tracing-subscriber",
 ]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -562,7 +562,7 @@ mod governor_tests {
                 .error_handler(|_| {
                     http::Response::builder()
                         .status(http::StatusCode::IM_A_TEAPOT)
-                        .body(String::from("a custom error string"))
+                        .body(axum::body::Body::from("a custom error string"))
                         .unwrap()
                 })
                 .finish()


### PR DESCRIPTION
Replaces the `ErrorHandler` generic of a `String` response to a `axum::body::Body` response instead.

This is done to ensure that custom error handlers that do not explicitly return a `String` can still be used (should close #21). A test was modified to use a `Body` instead of a `String`.