### PR TITLE
Make as_response pub

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,7 +22,9 @@ pub enum GovernorError {
 }
 
 impl GovernorError {
-    pub(crate) fn as_response<ResB>(&mut self) -> Response<ResB>
+    /// Convert self into a "default response", as if no error handler was set using
+    /// [`GovernorConfigBuilder::error_handler`].
+    pub fn as_response<ResB>(&mut self) -> Response<ResB>
     where
         ResB: From<String>,
     {


### PR DESCRIPTION
This function is convenient from within custom error handlers, so that
only some part of the response (or one arm of the error enum) can be
overwritten.
