### PR TITLE
Make Clock a generic parameter

### DIFF
--- a/src/governor.rs
+++ b/src/governor.rs
@@ -66,6 +66,7 @@ pub struct GovernorConfigBuilder<
 impl<C: Clock + Clone + std::fmt::Debug>
     GovernorConfigBuilder<PeerIpKeyExtractor, NoOpMiddleware<C::Instant>, C>
 {
+    /// Creates a `GovernorConfigBuilder` with default parameters and a provided `Clock``
     pub fn default_with_clock(clock: C) -> Self {
         Self {
             period: DEFAULT_PERIOD,


### PR DESCRIPTION
This makes a `Clock` trait a generic parameter, allowing to use e.g. `FakeRelativeClock` in tests to avoid waiting.
Public API gets `default_with_clock()` method that allows creating a builder with a custom `Clock`.

`Clock` defaults to `DefaultClock` as before, so API shouldn't break, but since most of public types got additional generic parameter - some code that references them might break, so it's a breaking change.

I'm not sure if it's possible to avoid that since `Clock` generic parameter boils down to `RateLimiter` from `governor` crate and `RateLimiter` doesn't expose any specific trait it seems so we can't just `Box<dyn ...>` it... maybe I am missing something here.