### PR TITLE
fix: add 1 second to wait_time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use http::request::Request;
 use http::HeaderMap;
 use key_extractor::KeyExtractor;
 use pin_project::pin_project;
+use std::ops::Add;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::{future::Future, pin::Pin, task::ready};
@@ -124,7 +125,8 @@ where
                 Err(negative) => {
                     let wait_time = negative
                         .wait_time_from(DefaultClock::default().now())
-                        .as_secs();
+                        .as_secs()
+                        .add(1);
 
                     #[cfg(feature = "tracing")]
                     {


### PR DESCRIPTION
Clients may use the wait_time to retry the request, returning 1 sec as soon as wait_time is under 1 sec will guarantee the next request will succeed.